### PR TITLE
Replace deprecated browser interaction code : Change dynCall to makeD…

### DIFF
--- a/Assets/UnityWebSocket/Plugins/WebGL/WebSocket.jslib
+++ b/Assets/UnityWebSocket/Plugins/WebGL/WebSocket.jslib
@@ -154,7 +154,7 @@ var WebSocketLibrary =
 
         instance.ws.onopen = function()
         {
-            Module.dynCall_vi(webSocketManager.onOpen, instanceId);
+            {{{ makeDynCall('vi', 'webSocketManager.onOpen') }}}(instanceId);
         };
 
         instance.ws.onmessage = function(ev)
@@ -166,7 +166,7 @@ var WebSocketLibrary =
                 writeArrayToMemory(array, buffer);
                 try
                 {
-                    Module.dynCall_viii(webSocketManager.onMessage, instanceId, buffer, array.length);
+                    {{{ makeDynCall('viii', 'webSocketManager.onMessage') }}}(instanceId, buffer, array.length);
                 }
                 finally
                 {
@@ -180,7 +180,7 @@ var WebSocketLibrary =
                 stringToUTF8(ev.data, buffer, length);
                 try
                 {
-                    Module.dynCall_vii(webSocketManager.onMessageStr, instanceId, buffer);
+                    {{{ makeDynCall('vii', 'webSocketManager.onMessageStr') }}}(instanceId, buffer);
                 }
                 finally
                 {
@@ -197,7 +197,7 @@ var WebSocketLibrary =
                     writeArrayToMemory(array, buffer);
                     try
                     {
-                        Module.dynCall_viii(webSocketManager.onMessage, instanceId, buffer, array.length);
+                        {{{ makeDynCall('viii', 'webSocketManager.onMessage') }}}(instanceId, buffer, array.length);
                     }
                     finally
                     {
@@ -221,7 +221,7 @@ var WebSocketLibrary =
             stringToUTF8(msg, buffer, length);
             try
             {
-                Module.dynCall_vii(webSocketManager.onError, instanceId, buffer);
+                {{{ makeDynCall('vii', 'webSocketManager.onError') }}}(instanceId, buffer);
             }
             finally
             {
@@ -237,7 +237,7 @@ var WebSocketLibrary =
             stringToUTF8(msg, buffer, length);
             try
             {
-                Module.dynCall_viii(webSocketManager.onClose, instanceId, ev.code, buffer);
+                {{{ makeDynCall('viii', 'webSocketManager.onClose') }}}(instanceId, ev.code, buffer);
             }
             finally
             {


### PR DESCRIPTION
From unity documentation : https://docs.unity3d.com/6000.0/Documentation/Manual/web-interacting-browser-deprecated.html
"Some code involved with web browser script interactions is deprecated and has been replaced with alternative code.

If your code contains any of the deprecated code, you need to update the code with the replacement code to prevent unexpected behavior or broken code."

Using Unity 6 with Target WebAssembly 2023, Module.dynCall throw not defined errors. 
This changes resolve the issue.